### PR TITLE
style: avoid horizontal overflow on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -82,7 +82,8 @@ header {
 
 @media screen and (max-width: 644px) {
     .container {
-    height: auto;    }
+    height: auto;
+    width: 100%;    }
   }
 
 .container-calc {


### PR DESCRIPTION
- by setting with of .container to 100%
- closes #2 